### PR TITLE
Updated sbt-pgp and sbt-sonatype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,9 +7,9 @@ lazy val `sbt-release-early` = project
     pgpSecretRing := file("/drone/.gnupg/secring.asc"),
     scalaVersion := "2.10.6",
     addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1"),
-    addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1"),
+    addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0"),
     addSbtPlugin("com.dwijnand" % "sbt-dynver" % "2.0.0"),
-    addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1"),
+    addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0"),
     scriptedLaunchOpts := Seq(
       "-Dplugin.version=" + version.value,
       "-Xmx1g",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,6 +11,6 @@ unmanagedSourceDirectories in Compile +=
 // This is required only for the recursive plugin dependency
 // Users of this plugin don't need to add this to their plugins.sbt
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "2.0.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")


### PR DESCRIPTION
This updates (on both project levels)
- sbt-pgp from 1.0.1 to 1.1.0
- sbt-sonatype from 1.1 to 2.0

By the way, I think both versions are published for sbt 0.13 and 1.0