### PR TITLE
Make Sonatype the default publisher

### DIFF
--- a/src/main/scala/ch/epfl/scala/sbt/release/ReleaseEarlyPlugin.scala
+++ b/src/main/scala/ch/epfl/scala/sbt/release/ReleaseEarlyPlugin.scala
@@ -190,7 +190,7 @@ object ReleaseEarly {
       Def.setting(false)
 
     val releaseEarlyWith: Def.Initialize[UnderlyingPublisher] =
-      Def.setting(BintrayPublisher)
+      Def.setting(SonatypePublisher)
 
     val releaseEarlyInsideCI: Def.Initialize[Boolean] =
       Def.setting(sys.env.get("CI").isDefined)

--- a/src/sbt-test/sbt-release-early/example-bintray/build.sbt
+++ b/src/sbt-test/sbt-release-early/example-bintray/build.sbt
@@ -4,6 +4,7 @@ lazy val publishSettings = Seq(
   bintrayRepository := "tools",
   bintrayPackageLabels := Seq("scala", "scalacenter", "plugin", "sbt"),
   publishTo := (publishTo in bintray).value,
+  releaseEarlyWith := BintrayPublisher,
   publishArtifact in Test := false,
   licenses := Seq(
     // Scala Center license... BSD 3-clause

--- a/src/sbt-test/sbt-release-early/simple-module-missing-license/changes/build-good.sbt
+++ b/src/sbt-test/sbt-release-early/simple-module-missing-license/changes/build-good.sbt
@@ -28,6 +28,7 @@ bintrayOrganization := None
 bintrayRepository := "releases"
 bintrayPackage := "root-example"
 publishTo := (publishTo in bintray).value
+releaseEarlyWith := BintrayPublisher
 
 // Release early
 releaseEarlyEnableLocalReleases := true

--- a/src/sbt-test/sbt-release-early/simple-module/build.sbt
+++ b/src/sbt-test/sbt-release-early/simple-module/build.sbt
@@ -24,6 +24,7 @@ bintrayOrganization := None
 bintrayRepository := "releases"
 bintrayPackage := "root-example"
 publishTo := (publishTo in bintray).value
+releaseEarlyWith := BintrayPublisher
 
 // Release early
 releaseEarlyEnableLocalReleases := true


### PR DESCRIPTION
This is a change I wanted to do some time ago, but waited for the perfect
moment to bump up the major version number. My experience releasing tells me to
recommend Sonatype, and therefore I want to make it the default publisher.

This will require a change in the docs.