### PR TITLE
Add back javadoc generation to the build

### DIFF
--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -57,7 +57,6 @@ object BuildDefaults {
     Keys.resolvers += Resolver.jcenterRepo,
     Keys.resolvers += Resolver.bintrayIvyRepo("scalacenter", "sbt-releases"),
     Keys.updateOptions := Keys.updateOptions.value.withCachedResolution(true),
-    Keys.publishArtifact in (Compile, Keys.packageDoc) := false
   )
 
   final val projectSettings: Seq[Def.Setting[_]] = Seq(


### PR DESCRIPTION
So that sonatype publishing doesn't fail.